### PR TITLE
Added auto-start and auto-load json asset using ros parameters. Also modified handling of path to plugins directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -311,3 +311,5 @@ TSWLatexianTemp*
 *.pidb
 *.svclog
 *.scc
+
+*.kate-swp

--- a/veranda/Packages/qt_frontend/builtin_qt_frontend_plugins/pkg-veranda_qt_frontend_default_robot_file_handler/CMakeLists.txt
+++ b/veranda/Packages/qt_frontend/builtin_qt_frontend_plugins/pkg-veranda_qt_frontend_default_robot_file_handler/CMakeLists.txt
@@ -83,10 +83,12 @@ ament_target_dependencies(default_robot_loader_plugin
     "veranda_qt_frontend_plugin_api"
 )
 
+ament_index_get_resource(PLUGIN_PATH "veranda_plugin_path" "veranda_qt_frontend")
+
 ## Install lib into same directory as simulator executable
 install(
   TARGETS default_robot_loader_plugin
-  DESTINATION ../veranda_plugins
+  DESTINATION ${PLUGIN_PATH}
 )
 
 ament_package()

--- a/veranda/Packages/qt_frontend/builtin_qt_frontend_plugins/pkg-veranda_qt_frontend_default_robot_file_handler/package.xml
+++ b/veranda/Packages/qt_frontend/builtin_qt_frontend_plugins/pkg-veranda_qt_frontend_default_robot_file_handler/package.xml
@@ -8,6 +8,8 @@
 
   <license>TODO</license>
 
+  <build_depend>veranda_qt_frontend</build_depend>
+
   <depend>veranda_core_api</depend>
   <depend>veranda_box2d</depend>
   <depend>veranda_qt_frontend_plugin_api</depend>

--- a/veranda/Packages/qt_frontend/builtin_qt_frontend_plugins/pkg-veranda_qt_frontend_image_file_handler/CMakeLists.txt
+++ b/veranda/Packages/qt_frontend/builtin_qt_frontend_plugins/pkg-veranda_qt_frontend_image_file_handler/CMakeLists.txt
@@ -87,10 +87,12 @@ ament_target_dependencies(image_loader_plugin
     "veranda_qt_frontend_plugin_api"
 )
 
+ament_index_get_resource(PLUGIN_PATH "veranda_plugin_path" "veranda_qt_frontend")
+
 ## Install lib into same directory as simulator executable
 install(
   TARGETS image_loader_plugin
-  DESTINATION ../veranda_plugins
+  DESTINATION ${PLUGIN_PATH}
 )
 
 ament_package()

--- a/veranda/Packages/qt_frontend/builtin_qt_frontend_plugins/pkg-veranda_qt_frontend_image_file_handler/package.xml
+++ b/veranda/Packages/qt_frontend/builtin_qt_frontend_plugins/pkg-veranda_qt_frontend_image_file_handler/package.xml
@@ -9,6 +9,8 @@
 
   <license>TODO</license>
 
+  <build_depend>veranda_qt_frontend</build_depend>
+
   <depend>veranda_core_api</depend>
   <depend>veranda_box2d</depend>
   <depend>veranda_qt_frontend_plugin_api</depend>

--- a/veranda/Packages/qt_frontend/builtin_qt_frontend_plugins/pkg-veranda_qt_frontend_json_file_handler/CMakeLists.txt
+++ b/veranda/Packages/qt_frontend/builtin_qt_frontend_plugins/pkg-veranda_qt_frontend_json_file_handler/CMakeLists.txt
@@ -34,6 +34,7 @@ ament_export_dependencies(
     veranda_core_api
     veranda_box2d
     veranda_qt_frontend_plugin_api
+    veranda_qt_frontend
 )
 
 
@@ -59,10 +60,12 @@ function(make_plugin plugin_name plugin_moc_hdrs plugin_srcs)
         "veranda_core_api"
         "veranda_qt_frontend_plugin_api")
 
+    ament_index_get_resource(PLUGIN_PATH "veranda_plugin_path" "veranda_qt_frontend")
+
     ## Install lib into same directory as simulator executable
     install(
       TARGETS ${plugin_name}
-      DESTINATION ../veranda_plugins
+      DESTINATION ${PLUGIN_PATH}
     )
 endfunction()
 

--- a/veranda/Packages/qt_frontend/builtin_qt_frontend_plugins/pkg-veranda_qt_frontend_json_file_handler/package.xml
+++ b/veranda/Packages/qt_frontend/builtin_qt_frontend_plugins/pkg-veranda_qt_frontend_json_file_handler/package.xml
@@ -8,6 +8,8 @@
 
   <license>TODO</license>
 
+  <build_depend>veranda_qt_frontend</build_depend>
+
   <depend>veranda_core_api</depend>
   <depend>veranda_box2d</depend>
   <depend>veranda_qt_frontend_plugin_api</depend>

--- a/veranda/Packages/qt_frontend/pkg-veranda_qt_frontend/CMakeLists.txt
+++ b/veranda/Packages/qt_frontend/pkg-veranda_qt_frontend/CMakeLists.txt
@@ -15,6 +15,7 @@ endif()
 
 ## Find required ROS packages
 find_package(ament_cmake REQUIRED)
+find_package(ament_index_cpp REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
@@ -45,6 +46,8 @@ ament_export_dependencies(
     veranda_qt_frontend_plugin_api
     veranda_qt_plugin_api
 )
+
+ament_index_register_resource(veranda_plugin_path CONTENT "${CMAKE_INSTALL_PREFIX}/lib/veranda_qt_frontend")
 
 ###################
 ## FILE LISTINGS ##
@@ -114,6 +117,7 @@ qt5_use_modules(${EXE_NAME} ${QT_COMPONENTS})
 ## Pull in stuff exported from other packages
 ament_target_dependencies(${EXE_NAME}
     "rclcpp"
+    "ament_index_cpp"
     "std_msgs"
     "sensor_msgs"
     "veranda_box2d"
@@ -132,6 +136,12 @@ install(
   TARGETS ${EXE_NAME}
   DESTINATION lib/${PROJECT_NAME}
 )
+
+install(DIRECTORY
+        config
+        launch
+        DESTINATION share/${PROJECT_NAME}/
+        )
 
 ## On windows, we need to run windeployqt
 ## To set up plugins and dlls because Windows

--- a/veranda/Packages/qt_frontend/pkg-veranda_qt_frontend/config/veranda_qt_frontend.yaml
+++ b/veranda/Packages/qt_frontend/pkg-veranda_qt_frontend/config/veranda_qt_frontend.yaml
@@ -1,0 +1,7 @@
+veranda:
+  ros__parameters:
+
+    auto_start_sim: yes
+
+    auto_load_asset: no
+    json_asset_path: "/path/to/asset/my_asset.json"

--- a/veranda/Packages/qt_frontend/pkg-veranda_qt_frontend/launch/launch_file_parameters.launch.py
+++ b/veranda/Packages/qt_frontend/pkg-veranda_qt_frontend/launch/launch_file_parameters.launch.py
@@ -1,0 +1,16 @@
+import launch
+import launch.actions
+import launch.substitutions
+import launch_ros.actions
+
+
+def generate_launch_description():
+
+    return launch.LaunchDescription([
+        launch_ros.actions.Node(
+            package='veranda_qt_frontend',
+            node_executable='veranda',
+            output='screen',
+            parameters=[{'auto_load_asset': 'no','json_asset_path': '/path/to/asset/my_asset.json', 'auto_start_sim': 'yes'}]
+        )
+    ])

--- a/veranda/Packages/qt_frontend/pkg-veranda_qt_frontend/launch/load_yaml_parameters.launch.py
+++ b/veranda/Packages/qt_frontend/pkg-veranda_qt_frontend/launch/load_yaml_parameters.launch.py
@@ -1,0 +1,21 @@
+import launch
+import launch.actions
+import launch.substitutions
+import launch_ros.actions
+
+from pathlib import Path
+from ament_index_python.packages import get_package_share_directory
+
+
+def generate_launch_description():
+    parameter_file_veranda = Path(get_package_share_directory('veranda_qt_frontend'), 'config', 'veranda_qt_frontend.yaml')
+    assert parameter_file_veranda.is_file()
+
+    return launch.LaunchDescription([
+        launch_ros.actions.Node(
+            package='veranda_qt_frontend',
+            node_executable='veranda',
+            output='screen',
+            parameters=[parameter_file_veranda]
+        )
+    ])

--- a/veranda/Packages/qt_frontend/pkg-veranda_qt_frontend/package.xml
+++ b/veranda/Packages/qt_frontend/pkg-veranda_qt_frontend/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>veranda_qt_frontend</name>
   <version>0.0.1</version>
   <description>2D Qt UI for Veranda</description>
@@ -10,14 +10,19 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>veranda_box2d</depend>
-  <depend>veranda_core_api</depend>
-  <depend>veranda_core</depend>
-  <depend>veranda_qt_plugin_api</depend>
-  <depend>veranda_qt_frontend_plugin_api</depend>
-  <depend>rclcpp</depend>
-  <depend>std_msgs</depend>
-  <depend>sensor_msgs</depend>
+  <build_depend>veranda_box2d</build_depend>
+  <build_depend>veranda_core_api</build_depend>
+  <build_depend>veranda_core</build_depend>
+  <build_depend>veranda_qt_plugin_api</build_depend>
+  <build_depend>veranda_qt_frontend_plugin_api</build_depend>
+  <build_depend>rclcpp</build_depend>
+  <build_depend>ament_index_cpp</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+
+  <exec_depend>rclcpp</exec_depend>
+  <exec_depend>ament_index_cpp</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/veranda/Packages/qt_plugins/pkg-veranda_builtin_plugin_qt_wrappers/CMakeLists.txt
+++ b/veranda/Packages/qt_plugins/pkg-veranda_builtin_plugin_qt_wrappers/CMakeLists.txt
@@ -69,10 +69,12 @@ function(make_plugin plugin_name plugin_moc_hdrs plugin_srcs plugin_roslib)
         "veranda_core_api"
         "${plugin_roslib}")
 
+    ament_index_get_resource(PLUGIN_PATH "veranda_plugin_path" "veranda_qt_frontend")
+
     ## Install lib into same directory as simulator executable
     install(
       TARGETS ${plugin_name}
-      DESTINATION ../veranda_plugins
+      DESTINATION ${PLUGIN_PATH}
     )
 endfunction()
 

--- a/veranda/Packages/qt_plugins/pkg-veranda_builtin_plugin_qt_wrappers/package.xml
+++ b/veranda/Packages/qt_plugins/pkg-veranda_builtin_plugin_qt_wrappers/package.xml
@@ -8,6 +8,8 @@
 
   <license>TODO</license>
 
+  <build_depend>veranda_qt_frontend</build_depend>
+
   <depend>veranda_core_api</depend>
   <depend>veranda_qt_plugin_api</depend>   
   <depend>veranda_builtin_sensors</depend>


### PR DESCRIPTION
- Added posibility to auto load json asset and auto start simulation using ros parameters

- Made example launch files

- Changed directory for plugins to install share lib directory for qt-frontend package (This now works on Dashing). Registred this path in cmake with ament_index_register_resource. For installation of future plugins this path is available from cmake using ament_index_get_resource.

Tested on Dashing with Ubuntu 18